### PR TITLE
Send addresses as strings instead of objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resend (0.1.1)
+    resend (0.2.1)
       httparty (~> 0.20.0)
 
 GEM
@@ -189,6 +189,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/lib/resend/mailer.rb
+++ b/lib/resend/mailer.rb
@@ -18,9 +18,9 @@ module Resend
         to: mail.to,
         subject: mail.subject,
       }
-      params[:cc] = mail[:cc] if mail[:cc].present?
-      params[:bcc] = mail[:bcc] if mail[:bcc].present?
-      params[:reply_to] = mail[:reply_to] if mail[:reply_to].present?
+      params[:cc] = mail[:cc].to_s if mail[:cc].present?
+      params[:bcc] = mail[:bcc].to_s if mail[:bcc].present?
+      params[:reply_to] = mail[:reply_to].to_s if mail[:reply_to].present?
       params[:html] = mail.body.decoded
 
       resp = @resend_client.send_email(params)

--- a/lib/resend/version.rb
+++ b/lib/resend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resend
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Fixes
```
{
    "error": {
        "type": "SerializationException",
        "message": "Start of structure or map found where not expected."
    }
}
```

when replay_to option provided